### PR TITLE
Use NSInteger for error codes

### DIFF
--- a/RMError/RMError/NSError+RMError.h
+++ b/RMError/RMError/NSError+RMError.h
@@ -14,7 +14,7 @@ FOUNDATION_EXPORT NSError * RMErrorCreate(NSString *errorDescription);
 
 
 extern NSString * const RMErrorDomainDefault;
-extern NSUInteger const RMErrorCodeDefault;
+extern NSInteger const RMErrorCodeDefault;
 
 
 /**
@@ -25,20 +25,20 @@ extern NSUInteger const RMErrorCodeDefault;
 /**
  Creates and initializes an NSError object for a given domain, code and description. The <code>description</code> parameter is what will be accessable as <code>error.localizedDescription</code>. If the domain is nil then <code>RMErrorDomainDefault</code> is used as domain.
  */
-+ (instancetype)errorWithCode:(NSUInteger)code
++ (instancetype)errorWithCode:(NSInteger)code
                   description:(NSString *)description
                        domain:(NSString *)domain;
 
 /**
  Creates and initializes an NSError object for a given code and description. The <code>description</code> parameter is what will be accessable as <code>error.localizedDescription</code>. The domain of this error will be <code>RMErrorDomainDefault</code>.
  */
-+ (instancetype)errorWithCode:(NSUInteger)code
++ (instancetype)errorWithCode:(NSInteger)code
                   description:(NSString *)description;
 
 /**
  Creates an error with an error code and <code>RMErrorDomainDefault</code> as domain. The discription will be empty.
  */
-+ (instancetype)errorWithCode:(NSUInteger)code;
++ (instancetype)errorWithCode:(NSInteger)code;
 
 /**
  Creates an error with a localizedDescription and <code>RMErrorDomainDefault</code> as domain. The error code will be <code>RMErrorCodeDefault</code>.

--- a/RMError/RMError/NSError+RMError.m
+++ b/RMError/RMError/NSError+RMError.m
@@ -16,14 +16,14 @@ FOUNDATION_EXTERN NSError * RMErrorCreate(NSString *errorDescription)
 
 
 NSString * const RMErrorDomainDefault = @"RMErrorDomainDefault";
-NSUInteger const RMErrorCodeDefault = 0;
+NSInteger const RMErrorCodeDefault = 0;
 
 
 @implementation NSError (RMError)
 
 #pragma mark - Factory methods
 
-+ (instancetype)errorWithCode:(NSUInteger)code
++ (instancetype)errorWithCode:(NSInteger)code
                   description:(NSString *)description
                        domain:(NSString *)domain
 {
@@ -46,7 +46,7 @@ NSUInteger const RMErrorCodeDefault = 0;
 }
 
 
-+ (instancetype)errorWithCode:(NSUInteger)code
++ (instancetype)errorWithCode:(NSInteger)code
                   description:(NSString *)description
 {
     return [NSError errorWithCode:code
@@ -55,7 +55,7 @@ NSUInteger const RMErrorCodeDefault = 0;
 }
 
 
-+ (instancetype)errorWithCode:(NSUInteger)code
++ (instancetype)errorWithCode:(NSInteger)code
 {
     return [NSError errorWithCode:code
                       description:nil


### PR DESCRIPTION
This is necessary to have negative error codes in Swift.